### PR TITLE
Add Helm chart for Kubernetes deployment

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,56 @@
+# Docker Setup for AI Hedge Fund
+
+This document explains how to run the AI Hedge Fund application using Docker.
+
+## Prerequisites
+
+- Docker installed on your system
+- Docker Compose installed on your system
+
+## Quick Start
+
+1. Create a `.env` file with your API keys (copy from `.env.example` and fill in your values)
+
+2. Build and run the application using Docker Compose:
+
+```bash
+docker-compose up --build
+```
+
+This will start the application with default parameters (analyzing AAPL, MSFT, and GOOGL stocks).
+
+## Customizing Parameters
+
+You can modify the `docker-compose.yml` file to change the command-line arguments:
+
+```yaml
+command: ["--tickers", "AAPL,MSFT,GOOGL", "--show-reasoning"]
+```
+
+Available parameters:
+- `--tickers`: Comma-separated list of stock ticker symbols
+- `--start-date`: Start date (YYYY-MM-DD)
+- `--end-date`: End date (YYYY-MM-DD)
+- `--initial-cash`: Initial cash position (default: 100000.0)
+- `--margin-requirement`: Initial margin requirement (default: 0.0)
+- `--show-reasoning`: Show reasoning from each agent
+- `--show-agent-graph`: Show the agent graph
+
+## Running with Custom Parameters
+
+You can also run the Docker container directly with custom parameters:
+
+```bash
+docker build -t ai-hedge-fund .
+docker run -it --env-file .env ai-hedge-fund --tickers TSLA,AMZN --start-date 2023-01-01 --end-date 2023-12-31
+```
+
+## Development with Docker
+
+For development, you can mount your local code into the container:
+
+```bash
+docker run -it --env-file .env -v $(pwd):/app ai-hedge-fund --tickers AAPL
+```
+
+This allows you to make changes to the code and see them reflected immediately in the container.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Poetry
+RUN curl -sSL https://install.python-poetry.org | python3 -
+ENV PATH="/root/.local/bin:$PATH"
+
+# Copy poetry configuration files
+COPY pyproject.toml poetry.lock* /app/
+
+# Configure poetry to not use virtualenvs inside the container
+RUN poetry config virtualenvs.create false
+
+# Install dependencies
+RUN poetry install --no-interaction --no-ansi --no-dev
+
+# Copy the rest of the application
+COPY . /app/
+
+# Create a non-root user to run the application
+RUN useradd -m appuser
+RUN chown -R appuser:appuser /app
+USER appuser
+
+# Set environment variables
+ENV PYTHONPATH=/app
+
+# Run the application
+ENTRYPOINT ["python", "src/main.py"]

--- a/charts/ai-hedge-fund/Chart.yaml
+++ b/charts/ai-hedge-fund/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: ai-hedge-fund
+description: A Helm chart for AI Hedge Fund application
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+keywords:
+  - ai
+  - finance
+  - trading
+maintainers:
+  - name: AI Hedge Fund Team
+    email: team@example.com

--- a/charts/ai-hedge-fund/README.md
+++ b/charts/ai-hedge-fund/README.md
@@ -1,0 +1,83 @@
+# AI Hedge Fund Helm Chart
+
+This Helm chart deploys the AI Hedge Fund application on a Kubernetes cluster.
+
+## Prerequisites
+
+- Kubernetes 1.19+
+- Helm 3.2.0+
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+# First, build and push the Docker image to your registry
+docker build -t your-registry/ai-hedge-fund:latest .
+docker push your-registry/ai-hedge-fund:latest
+
+# Then install the Helm chart
+helm install my-release ./charts/ai-hedge-fund \
+  --set image.repository=your-registry/ai-hedge-fund \
+  --set image.tag=latest \
+  --set secrets.data.OPENAI_API_KEY=your-openai-api-key
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+helm delete my-release
+```
+
+## Parameters
+
+### Global parameters
+
+| Name                      | Description                                     | Value |
+| ------------------------- | ----------------------------------------------- | ----- |
+| `replicaCount`            | Number of replicas to deploy                    | `1`   |
+| `image.repository`        | Image repository                                | `ai-hedge-fund` |
+| `image.tag`               | Image tag                                       | `latest` |
+| `image.pullPolicy`        | Image pull policy                               | `IfNotPresent` |
+
+### Application parameters
+
+| Name                           | Description                                | Value |
+| ------------------------------ | ------------------------------------------ | ----- |
+| `application.tickers`          | Comma-separated list of stock tickers      | `AAPL,MSFT,GOOGL` |
+| `application.initialCash`      | Initial cash position                      | `100000.0` |
+| `application.marginRequirement`| Initial margin requirement                 | `0.0` |
+| `application.showReasoning`    | Show reasoning from each agent             | `true` |
+| `application.showAgentGraph`   | Show the agent graph                       | `false` |
+
+### Secret parameters
+
+| Name                      | Description                                     | Value |
+| ------------------------- | ----------------------------------------------- | ----- |
+| `secrets.enabled`         | Enable secrets                                  | `true` |
+| `secrets.create`          | Create the secret                               | `true` |
+| `secrets.name`            | Name of the secret                              | `ai-hedge-fund-secrets` |
+| `secrets.data`            | Secret data to add                              | `{}` |
+
+## Example: Setting API Keys
+
+You can set your API keys in the `values.yaml` file:
+
+```yaml
+secrets:
+  enabled: true
+  create: true
+  data:
+    OPENAI_API_KEY: "your-openai-api-key"
+    ANTHROPIC_API_KEY: "your-anthropic-api-key"
+```
+
+Or you can pass them as command-line arguments:
+
+```bash
+helm install my-release ./charts/ai-hedge-fund \
+  --set secrets.data.OPENAI_API_KEY=your-openai-api-key \
+  --set secrets.data.ANTHROPIC_API_KEY=your-anthropic-api-key
+```

--- a/charts/ai-hedge-fund/templates/_helpers.tpl
+++ b/charts/ai-hedge-fund/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ai-hedge-fund.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "ai-hedge-fund.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "ai-hedge-fund.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "ai-hedge-fund.labels" -}}
+helm.sh/chart: {{ include "ai-hedge-fund.chart" . }}
+{{ include "ai-hedge-fund.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "ai-hedge-fund.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ai-hedge-fund.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "ai-hedge-fund.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "ai-hedge-fund.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/ai-hedge-fund/templates/deployment.yaml
+++ b/charts/ai-hedge-fund/templates/deployment.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ai-hedge-fund.fullname" . }}
+  labels:
+    {{- include "ai-hedge-fund.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "ai-hedge-fund.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "ai-hedge-fund.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "ai-hedge-fund.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "--tickers"
+            - "{{ .Values.application.tickers }}"
+            - "--initial-cash"
+            - "{{ .Values.application.initialCash }}"
+            - "--margin-requirement"
+            - "{{ .Values.application.marginRequirement }}"
+            {{- if .Values.application.showReasoning }}
+            - "--show-reasoning"
+            {{- end }}
+            {{- if .Values.application.showAgentGraph }}
+            - "--show-agent-graph"
+            {{- end }}
+          env:
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- if .Values.secrets.enabled }}
+            {{- range $key, $value := .Values.secrets.data }}
+            - name: {{ $key }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Values.secrets.name }}
+                  key: {{ $key }}
+            {{- end }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/ai-hedge-fund/templates/secrets.yaml
+++ b/charts/ai-hedge-fund/templates/secrets.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.secrets.enabled .Values.secrets.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.secrets.name }}
+  labels:
+    {{- include "ai-hedge-fund.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- range $key, $value := .Values.secrets.data }}
+  {{ $key }}: {{ $value | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/ai-hedge-fund/templates/service.yaml
+++ b/charts/ai-hedge-fund/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ai-hedge-fund.fullname" . }}
+  labels:
+    {{- include "ai-hedge-fund.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "ai-hedge-fund.selectorLabels" . | nindent 4 }}

--- a/charts/ai-hedge-fund/templates/serviceaccount.yaml
+++ b/charts/ai-hedge-fund/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "ai-hedge-fund.serviceAccountName" . }}
+  labels:
+    {{- include "ai-hedge-fund.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/ai-hedge-fund/values.yaml
+++ b/charts/ai-hedge-fund/values.yaml
@@ -1,0 +1,63 @@
+replicaCount: 1
+
+image:
+  repository: ai-hedge-fund
+  pullPolicy: IfNotPresent
+  tag: "latest"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+
+securityContext: {}
+
+service:
+  type: ClusterIP
+  port: 80
+
+resources:
+  limits:
+    cpu: 1
+    memory: 2Gi
+  requests:
+    cpu: 500m
+    memory: 1Gi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# Application specific configuration
+application:
+  tickers: "AAPL,MSFT,GOOGL"
+  initialCash: 100000.0
+  marginRequirement: 0.0
+  showReasoning: true
+  showAgentGraph: false
+
+# Environment variables to be passed to the application
+env:
+  # Add your environment variables here
+  # OPENAI_API_KEY: ""
+  # ANTHROPIC_API_KEY: ""
+
+# Secret containing API keys
+secrets:
+  enabled: true
+  name: ai-hedge-fund-secrets
+  # If you want to create the secret via Helm
+  create: true
+  data: {}
+    # OPENAI_API_KEY: ""
+    # ANTHROPIC_API_KEY: ""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.8'
+
+services:
+  ai-hedge-fund:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ./.env:/app/.env:ro
+    command: ["--tickers", "AAPL,MSFT,GOOGL", "--show-reasoning"]
+    environment:
+      - PYTHONUNBUFFERED=1
+    stdin_open: true
+    tty: true


### PR DESCRIPTION
This PR adds a Helm chart for deploying the AI Hedge Fund application to Kubernetes, including:

- Complete Helm chart structure with templates
- Values file for configuration
- Documentation on how to use the Helm chart