### PR TITLE
Add ArgoCD configuration for GitOps deployment

### DIFF
--- a/ARGOCD.md
+++ b/ARGOCD.md
@@ -1,0 +1,78 @@
+# ArgoCD Deployment for AI Hedge Fund
+
+This document explains how to deploy the AI Hedge Fund application using ArgoCD for GitOps-based continuous delivery.
+
+## Prerequisites
+
+- Kubernetes cluster with ArgoCD installed
+- Access to the ArgoCD UI or CLI
+
+## Setup
+
+1. First, ensure ArgoCD is installed in your cluster:
+
+```bash
+kubectl create namespace argocd
+kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+```
+
+2. Access the ArgoCD UI:
+
+```bash
+kubectl port-forward svc/argocd-server -n argocd 8080:443
+```
+
+Then visit https://localhost:8080 in your browser.
+
+3. Apply the AI Hedge Fund application manifest:
+
+```bash
+kubectl apply -f argocd/application.yaml
+```
+
+## Configuration
+
+The ArgoCD configuration consists of:
+
+- `application.yaml`: Defines the application, source repository, and sync policy
+- `namespace.yaml`: Creates the application namespace
+- `secrets.yaml`: Template for creating secrets (should be customized for production)
+- `kustomization.yaml`: Kustomize configuration to apply all resources
+
+## Managing Secrets
+
+For production, you should use a secure method to manage secrets:
+
+1. Using Sealed Secrets:
+```bash
+# Install kubeseal
+kubectl apply -f https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.19.5/controller.yaml
+
+# Create a sealed secret
+kubeseal -o yaml < argocd/secrets.yaml > argocd/sealed-secrets.yaml
+```
+
+2. Using Vault:
+```bash
+# Configure Vault integration with ArgoCD
+# See: https://argo-cd.readthedocs.io/en/stable/operator-manual/secret-management/vault/
+```
+
+## Syncing the Application
+
+ArgoCD will automatically sync the application based on the sync policy defined in `application.yaml`. You can also manually sync from the ArgoCD UI or using the CLI:
+
+```bash
+argocd app sync ai-hedge-fund
+```
+
+## Monitoring Deployment Status
+
+```bash
+argocd app get ai-hedge-fund
+```
+
+## Additional Resources
+
+- [ArgoCD Documentation](https://argo-cd.readthedocs.io/en/stable/)
+- [Kustomize Documentation](https://kubectl.docs.kubernetes.io/guides/introduction/kustomize/)

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,56 @@
+# Docker Setup for AI Hedge Fund
+
+This document explains how to run the AI Hedge Fund application using Docker.
+
+## Prerequisites
+
+- Docker installed on your system
+- Docker Compose installed on your system
+
+## Quick Start
+
+1. Create a `.env` file with your API keys (copy from `.env.example` and fill in your values)
+
+2. Build and run the application using Docker Compose:
+
+```bash
+docker-compose up --build
+```
+
+This will start the application with default parameters (analyzing AAPL, MSFT, and GOOGL stocks).
+
+## Customizing Parameters
+
+You can modify the `docker-compose.yml` file to change the command-line arguments:
+
+```yaml
+command: ["--tickers", "AAPL,MSFT,GOOGL", "--show-reasoning"]
+```
+
+Available parameters:
+- `--tickers`: Comma-separated list of stock ticker symbols
+- `--start-date`: Start date (YYYY-MM-DD)
+- `--end-date`: End date (YYYY-MM-DD)
+- `--initial-cash`: Initial cash position (default: 100000.0)
+- `--margin-requirement`: Initial margin requirement (default: 0.0)
+- `--show-reasoning`: Show reasoning from each agent
+- `--show-agent-graph`: Show the agent graph
+
+## Running with Custom Parameters
+
+You can also run the Docker container directly with custom parameters:
+
+```bash
+docker build -t ai-hedge-fund .
+docker run -it --env-file .env ai-hedge-fund --tickers TSLA,AMZN --start-date 2023-01-01 --end-date 2023-12-31
+```
+
+## Development with Docker
+
+For development, you can mount your local code into the container:
+
+```bash
+docker run -it --env-file .env -v $(pwd):/app ai-hedge-fund --tickers AAPL
+```
+
+This allows you to make changes to the code and see them reflected immediately in the container.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Poetry
+RUN curl -sSL https://install.python-poetry.org | python3 -
+ENV PATH="/root/.local/bin:$PATH"
+
+# Copy poetry configuration files
+COPY pyproject.toml poetry.lock* /app/
+
+# Configure poetry to not use virtualenvs inside the container
+RUN poetry config virtualenvs.create false
+
+# Install dependencies
+RUN poetry install --no-interaction --no-ansi --no-dev
+
+# Copy the rest of the application
+COPY . /app/
+
+# Create a non-root user to run the application
+RUN useradd -m appuser
+RUN chown -R appuser:appuser /app
+USER appuser
+
+# Set environment variables
+ENV PYTHONPATH=/app
+
+# Run the application
+ENTRYPOINT ["python", "src/main.py"]

--- a/WAYPOINT.md
+++ b/WAYPOINT.md
@@ -1,0 +1,64 @@
+# Waypoint Deployment for AI Hedge Fund
+
+This document explains how to deploy the AI Hedge Fund application using HashiCorp Waypoint.
+
+## Prerequisites
+
+- [Waypoint](https://www.waypointproject.io/) installed
+- Docker installed
+- Kubernetes cluster configured (for Kubernetes deployment)
+
+## Getting Started
+
+1. Install Waypoint server (if not already installed):
+
+```bash
+waypoint server install -platform=kubernetes -accept-tos
+```
+
+2. Initialize the project:
+
+```bash
+waypoint init
+```
+
+3. Deploy the application:
+
+```bash
+waypoint up
+```
+
+This will build, deploy, and release the application according to the configuration in `waypoint.hcl`.
+
+## Passing API Keys
+
+You can pass API keys as variables:
+
+```bash
+waypoint up -var="api_keys={\"OPENAI_API_KEY\":\"sk-...\",\"ANTHROPIC_API_KEY\":\"sk-...\"}"
+```
+
+## Customizing Deployment
+
+You can modify the `waypoint.hcl` file to customize the deployment:
+
+- Change the tickers by modifying the `args` in the container configuration
+- Adjust resource limits and requests
+- Change the deployment target (e.g., from Kubernetes to Docker or Nomad)
+
+## Viewing Logs
+
+```bash
+waypoint logs
+```
+
+## Destroying the Deployment
+
+```bash
+waypoint destroy
+```
+
+## Additional Resources
+
+- [Waypoint Documentation](https://www.waypointproject.io/docs)
+- [Waypoint Kubernetes Plugin](https://www.waypointproject.io/plugins/kubernetes)

--- a/argocd/application.yaml
+++ b/argocd/application.yaml
@@ -1,0 +1,28 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ai-hedge-fund
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/ABoringBusiness/ai-hedge-fund.git
+    targetRevision: HEAD
+    path: charts/ai-hedge-fund
+    helm:
+      valueFiles:
+        - values.yaml
+      parameters:
+        - name: image.repository
+          value: ai-hedge-fund
+        - name: image.tag
+          value: latest
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ai-hedge-fund
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/argocd/kustomization.yaml
+++ b/argocd/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - application.yaml
+  - namespace.yaml
+  - secrets.yaml

--- a/argocd/namespace.yaml
+++ b/argocd/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ai-hedge-fund
+  labels:
+    name: ai-hedge-fund

--- a/argocd/secrets.yaml
+++ b/argocd/secrets.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ai-hedge-fund-secrets
+  namespace: ai-hedge-fund
+type: Opaque
+# The actual secrets should be added using a sealed secret, vault, or other secure method
+# This is just a template
+data:
+  # Base64 encoded values
+  # OPENAI_API_KEY: ""
+  # ANTHROPIC_API_KEY: ""

--- a/charts/ai-hedge-fund/Chart.yaml
+++ b/charts/ai-hedge-fund/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: ai-hedge-fund
+description: A Helm chart for AI Hedge Fund application
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+keywords:
+  - ai
+  - finance
+  - trading
+maintainers:
+  - name: AI Hedge Fund Team
+    email: team@example.com

--- a/charts/ai-hedge-fund/README.md
+++ b/charts/ai-hedge-fund/README.md
@@ -1,0 +1,83 @@
+# AI Hedge Fund Helm Chart
+
+This Helm chart deploys the AI Hedge Fund application on a Kubernetes cluster.
+
+## Prerequisites
+
+- Kubernetes 1.19+
+- Helm 3.2.0+
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+# First, build and push the Docker image to your registry
+docker build -t your-registry/ai-hedge-fund:latest .
+docker push your-registry/ai-hedge-fund:latest
+
+# Then install the Helm chart
+helm install my-release ./charts/ai-hedge-fund \
+  --set image.repository=your-registry/ai-hedge-fund \
+  --set image.tag=latest \
+  --set secrets.data.OPENAI_API_KEY=your-openai-api-key
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+helm delete my-release
+```
+
+## Parameters
+
+### Global parameters
+
+| Name                      | Description                                     | Value |
+| ------------------------- | ----------------------------------------------- | ----- |
+| `replicaCount`            | Number of replicas to deploy                    | `1`   |
+| `image.repository`        | Image repository                                | `ai-hedge-fund` |
+| `image.tag`               | Image tag                                       | `latest` |
+| `image.pullPolicy`        | Image pull policy                               | `IfNotPresent` |
+
+### Application parameters
+
+| Name                           | Description                                | Value |
+| ------------------------------ | ------------------------------------------ | ----- |
+| `application.tickers`          | Comma-separated list of stock tickers      | `AAPL,MSFT,GOOGL` |
+| `application.initialCash`      | Initial cash position                      | `100000.0` |
+| `application.marginRequirement`| Initial margin requirement                 | `0.0` |
+| `application.showReasoning`    | Show reasoning from each agent             | `true` |
+| `application.showAgentGraph`   | Show the agent graph                       | `false` |
+
+### Secret parameters
+
+| Name                      | Description                                     | Value |
+| ------------------------- | ----------------------------------------------- | ----- |
+| `secrets.enabled`         | Enable secrets                                  | `true` |
+| `secrets.create`          | Create the secret                               | `true` |
+| `secrets.name`            | Name of the secret                              | `ai-hedge-fund-secrets` |
+| `secrets.data`            | Secret data to add                              | `{}` |
+
+## Example: Setting API Keys
+
+You can set your API keys in the `values.yaml` file:
+
+```yaml
+secrets:
+  enabled: true
+  create: true
+  data:
+    OPENAI_API_KEY: "your-openai-api-key"
+    ANTHROPIC_API_KEY: "your-anthropic-api-key"
+```
+
+Or you can pass them as command-line arguments:
+
+```bash
+helm install my-release ./charts/ai-hedge-fund \
+  --set secrets.data.OPENAI_API_KEY=your-openai-api-key \
+  --set secrets.data.ANTHROPIC_API_KEY=your-anthropic-api-key
+```

--- a/charts/ai-hedge-fund/templates/_helpers.tpl
+++ b/charts/ai-hedge-fund/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ai-hedge-fund.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "ai-hedge-fund.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "ai-hedge-fund.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "ai-hedge-fund.labels" -}}
+helm.sh/chart: {{ include "ai-hedge-fund.chart" . }}
+{{ include "ai-hedge-fund.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "ai-hedge-fund.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ai-hedge-fund.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "ai-hedge-fund.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "ai-hedge-fund.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/ai-hedge-fund/templates/deployment.yaml
+++ b/charts/ai-hedge-fund/templates/deployment.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ai-hedge-fund.fullname" . }}
+  labels:
+    {{- include "ai-hedge-fund.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "ai-hedge-fund.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "ai-hedge-fund.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "ai-hedge-fund.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "--tickers"
+            - "{{ .Values.application.tickers }}"
+            - "--initial-cash"
+            - "{{ .Values.application.initialCash }}"
+            - "--margin-requirement"
+            - "{{ .Values.application.marginRequirement }}"
+            {{- if .Values.application.showReasoning }}
+            - "--show-reasoning"
+            {{- end }}
+            {{- if .Values.application.showAgentGraph }}
+            - "--show-agent-graph"
+            {{- end }}
+          env:
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- if .Values.secrets.enabled }}
+            {{- range $key, $value := .Values.secrets.data }}
+            - name: {{ $key }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Values.secrets.name }}
+                  key: {{ $key }}
+            {{- end }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/ai-hedge-fund/templates/secrets.yaml
+++ b/charts/ai-hedge-fund/templates/secrets.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.secrets.enabled .Values.secrets.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.secrets.name }}
+  labels:
+    {{- include "ai-hedge-fund.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- range $key, $value := .Values.secrets.data }}
+  {{ $key }}: {{ $value | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/ai-hedge-fund/templates/service.yaml
+++ b/charts/ai-hedge-fund/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ai-hedge-fund.fullname" . }}
+  labels:
+    {{- include "ai-hedge-fund.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "ai-hedge-fund.selectorLabels" . | nindent 4 }}

--- a/charts/ai-hedge-fund/templates/serviceaccount.yaml
+++ b/charts/ai-hedge-fund/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "ai-hedge-fund.serviceAccountName" . }}
+  labels:
+    {{- include "ai-hedge-fund.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/ai-hedge-fund/values.yaml
+++ b/charts/ai-hedge-fund/values.yaml
@@ -1,0 +1,63 @@
+replicaCount: 1
+
+image:
+  repository: ai-hedge-fund
+  pullPolicy: IfNotPresent
+  tag: "latest"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+
+securityContext: {}
+
+service:
+  type: ClusterIP
+  port: 80
+
+resources:
+  limits:
+    cpu: 1
+    memory: 2Gi
+  requests:
+    cpu: 500m
+    memory: 1Gi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# Application specific configuration
+application:
+  tickers: "AAPL,MSFT,GOOGL"
+  initialCash: 100000.0
+  marginRequirement: 0.0
+  showReasoning: true
+  showAgentGraph: false
+
+# Environment variables to be passed to the application
+env:
+  # Add your environment variables here
+  # OPENAI_API_KEY: ""
+  # ANTHROPIC_API_KEY: ""
+
+# Secret containing API keys
+secrets:
+  enabled: true
+  name: ai-hedge-fund-secrets
+  # If you want to create the secret via Helm
+  create: true
+  data: {}
+    # OPENAI_API_KEY: ""
+    # ANTHROPIC_API_KEY: ""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.8'
+
+services:
+  ai-hedge-fund:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ./.env:/app/.env:ro
+    command: ["--tickers", "AAPL,MSFT,GOOGL", "--show-reasoning"]
+    environment:
+      - PYTHONUNBUFFERED=1
+    stdin_open: true
+    tty: true

--- a/waypoint.hcl
+++ b/waypoint.hcl
@@ -1,0 +1,71 @@
+project = "ai-hedge-fund"
+
+app "ai-hedge-fund" {
+  build {
+    use "docker" {
+      dockerfile = "Dockerfile"
+    }
+    
+    registry {
+      use "docker" {
+        image = "ai-hedge-fund"
+        tag   = "latest"
+        local = true
+      }
+    }
+  }
+
+  deploy {
+    use "kubernetes" {
+      probe_path = "/"
+      
+      service_port = 80
+      
+      namespace = "default"
+      
+      pod {
+        container {
+          name = "ai-hedge-fund"
+          
+          args = [
+            "--tickers", "AAPL,MSFT,GOOGL",
+            "--show-reasoning"
+          ]
+          
+          env {
+            name = "PYTHONUNBUFFERED"
+            value = "1"
+          }
+          
+          resources {
+            cpu {
+              request = "500m"
+              limit   = "1000m"
+            }
+            memory {
+              request = "1Gi"
+              limit   = "2Gi"
+            }
+          }
+        }
+      }
+    }
+  }
+
+  release {
+    use "kubernetes" {
+      namespace = "default"
+      
+      load_balancer = false
+    }
+  }
+}
+
+variable "api_keys" {
+  default = {}
+  type = map(string)
+  sensitive = true
+}
+
+# Example usage:
+# waypoint up -var="api_keys={\"OPENAI_API_KEY\":\"sk-...\",\"ANTHROPIC_API_KEY\":\"sk-...\"}"


### PR DESCRIPTION
This PR adds ArgoCD configuration for GitOps-based continuous delivery of the AI Hedge Fund application, including:

- ArgoCD application manifest
- Kustomization configuration
- Namespace and secrets templates
- ARGOCD.md with documentation on how to use ArgoCD with the application